### PR TITLE
improve readability of error handling

### DIFF
--- a/db.php
+++ b/db.php
@@ -34,35 +34,34 @@ class db
     {
         $this->closeOpenQuery();
 
-        if ($this->query = $this->connection->prepare($query)) {
-            if (func_num_args() > 1) {
-                $x = func_get_args();
-                $args = array_slice($x, 1);
-                $types = '';
-                $args_ref = array();
-                foreach ($args as $k => &$arg) {
-                    if (is_array($args[$k])) {
-                        foreach ($args[$k] as $j => &$a) {
-                            $types .= $this->_gettype($args[$k][$j]);
-                            $args_ref[] = &$a;
-                        }
-                    } else {
-                        $types .= $this->_gettype($args[$k]);
-                        $args_ref[] = &$arg;
-                    }
-                }
-                array_unshift($args_ref, $types);
-                call_user_func_array(array($this->query, 'bind_param'), $args_ref);
-            }
-            $this->query->execute();
-            if ($this->query->errno) {
-                $this->error('Unable to process MySQL query (check your params) - ' . $this->query->error);
-            }
-            $this->query_closed = FALSE;
-            $this->query_count++;
-        } else {
+        if (!$this->query = $this->connection->prepare($query)) {
             $this->error('Unable to prepare MySQL statement (check your syntax) - ' . $this->connection->error);
         }
+        if (func_num_args() > 1) {
+            $x = func_get_args();
+            $args = array_slice($x, 1);
+            $types = '';
+            $args_ref = array();
+            foreach ($args as $k => &$arg) {
+                if (is_array($args[$k])) {
+                    foreach ($args[$k] as $j => &$a) {
+                        $types .= $this->_gettype($args[$k][$j]);
+                        $args_ref[] = &$a;
+                    }
+                } else {
+                    $types .= $this->_gettype($args[$k]);
+                    $args_ref[] = &$arg;
+                }
+            }
+            array_unshift($args_ref, $types);
+            call_user_func_array(array($this->query, 'bind_param'), $args_ref);
+        }
+        $this->query->execute();
+        if ($this->query->errno) {
+            $this->error('Unable to process MySQL query (check your params) - ' . $this->query->error);
+        }
+        $this->query_closed = FALSE;
+        $this->query_count++;
         return $this;
     }
 


### PR DESCRIPTION
I moved the the "prepare failed" section up to the place, where the action happened.
Either we fail in this line of code, or we can proceed...
Think the readability is improved.

Sorry for the strange diff formating. :-(

